### PR TITLE
[Feature] JPA metamodel must not be empty! 해결

### DIFF
--- a/src/main/java/com/docde/DocDeApplication.java
+++ b/src/main/java/com/docde/DocDeApplication.java
@@ -2,10 +2,8 @@ package com.docde;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class DocDeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/docde/config/EnableJpaAuditingConfiguration.java
+++ b/src/main/java/com/docde/config/EnableJpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.docde.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class EnableJpaAuditingConfiguration {
+}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `JPA metamodel must not be empty!` 해결

## 참고 자료
[에러 : JPA metamodel must not be empty! 해결기
](https://velog.io/@cjh8746/%EC%97%90%EB%9F%AC-JPA-metamodel-must-not-be-empty-%ED%95%B4%EA%B2%B0%EA%B8%B0)