### PR TITLE
UPDATE: 진료기록 특정 사용자 조회 추가(QueryDsl사용), FIX:의사용/환자용 진료기록 수정을 통합해서 수정하도…

### DIFF
--- a/src/main/java/com/docde/common/Apiresponse/ErrorStatus.java
+++ b/src/main/java/com/docde/common/Apiresponse/ErrorStatus.java
@@ -2,6 +2,7 @@ package com.docde.common.Apiresponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.apache.http.protocol.HTTP;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -61,11 +62,12 @@ public enum ErrorStatus implements BaseCode {
     // 환자 관련 코드
     _NOT_FOUND_PATIENT(HttpStatus.NOT_FOUND, 404, "환자를 찾을 수 없습니다."),
 
-    // 진료 관련 코드
+    // 진기록 관련 코드
     _NOT_FOUND_MEDICAL_RECORD(HttpStatus.NOT_FOUND, 404, "진료기록을 찾을 수 없습니다."),
+    _UNAUTHORIZED_ACCESS_MEDICAL_RECORD(HttpStatus.UNAUTHORIZED,403,"진료기록에 대한 접근이 허용되지 않습니다."),
 
     // 리뷰 관련 코드
-    _NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, 404, "해당 리뷰를 찾을 수 없습니다."),
+    _NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, 404,    "해당 리뷰를 찾을 수 없습니다."),
     _FORBIDDEN_REVIEW_ACCESS(HttpStatus.FORBIDDEN, 403, "리뷰를 작성한 사용자가 아닙니다."),
 
     //접수 관련 코드

--- a/src/main/java/com/docde/config/QueryDslConfig.java
+++ b/src/main/java/com/docde/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.docde.config;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
+    }
+}

--- a/src/main/java/com/docde/domain/medicalRecord/controller/MedicalRecordController.java
+++ b/src/main/java/com/docde/domain/medicalRecord/controller/MedicalRecordController.java
@@ -3,7 +3,6 @@ package com.docde.domain.medicalRecord.controller;
 import com.docde.common.Apiresponse.ApiResponse;
 import com.docde.domain.auth.entity.AuthUser;
 import com.docde.domain.medicalRecord.dto.request.DoctorMedicalRecordRequestDto;
-import com.docde.domain.medicalRecord.dto.request.PatientMedicalRecordRequestDto;
 import com.docde.domain.medicalRecord.dto.response.DoctorMedicalRecordResponseDto;
 import com.docde.domain.medicalRecord.dto.response.MedicalRecordResponseDto;
 import com.docde.domain.medicalRecord.dto.response.PatientMedicalRecordResponseDto;
@@ -21,7 +20,6 @@ public class MedicalRecordController {
 
     private final MedicalRecordService medicalRecordService;
 
-
     @PostMapping("/medical-records")
     public ApiResponse<MedicalRecordResponseDto> createMedicalRecord(
             @RequestBody DoctorMedicalRecordRequestDto requestDto,
@@ -33,7 +31,21 @@ public class MedicalRecordController {
         return ApiResponse.createSuccess("진료 기록이 성공적으로 생성되었습니다.", 200, responseDto);
     }
 
-    // 의사가 의사용 진료 기록 조회
+    // 특정 진료기록 조회
+    @GetMapping("/doctors/medical-records/{medicalRecordId}")
+    public ApiResponse<DoctorMedicalRecordResponseDto> getSpecificDoctorMedicalRecord(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long medicalRecordId,
+            @RequestParam(required = false) String description,
+            @RequestParam(required = false) String treatmentPlan,
+            @RequestParam(required = false) String doctorComment) {
+
+        DoctorMedicalRecordResponseDto responseDto = medicalRecordService
+                .getSpecificDoctorMedicalRecord(authUser, medicalRecordId, description, treatmentPlan, doctorComment);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    // 의사가 의사용 진료기록 조회
     @GetMapping("/doctors/medical-records")
     public ApiResponse<List<DoctorMedicalRecordResponseDto>> getDoctorMedicalRecord(
             @AuthenticationPrincipal AuthUser authUser) {
@@ -43,7 +55,7 @@ public class MedicalRecordController {
     }
 
 
-    // 환자가 자신의 진료 기록 조회
+    // 환자가 자신의 진료기록 조회
     @GetMapping("/patients/medical-records")
     public ApiResponse<List<PatientMedicalRecordResponseDto>> getPatientMedicalRecord(
             @AuthenticationPrincipal AuthUser authUser) {
@@ -53,7 +65,24 @@ public class MedicalRecordController {
     }
 
 
-    // 의사용 진료기록 수정
+    // 진료기록 수정
+    @PutMapping("/doctors/medical-records/{medicalRecordId}")
+    public ApiResponse<MedicalRecordResponseDto> updateMedicalRecord(
+            @PathVariable Long medicalRecordId,
+            @RequestBody DoctorMedicalRecordRequestDto doctorRequestDto,
+            @AuthenticationPrincipal AuthUser authUser) {
+
+        MedicalRecordResponseDto responseDto = medicalRecordService.updateMedicalRecord(
+                medicalRecordId,
+                doctorRequestDto,
+                authUser
+        );
+
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+
+/*    // 의사용 진료기록 수정
     @PutMapping("/doctors/medical-records/{medicalRecordId}")
     public ApiResponse<DoctorMedicalRecordResponseDto> updateDoctorMedicalRecord(
             @AuthenticationPrincipal AuthUser authUser,
@@ -82,8 +111,7 @@ public class MedicalRecordController {
         );
 
         return ApiResponse.onSuccess(responseDto);
-    }
-
+    }*/
 
     // 진료기록 삭제
     @DeleteMapping("/medical-records/{medicalRecordId}")

--- a/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepository.java
+++ b/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepository.java
@@ -5,14 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Long> {
-
-    /*@Query("SELECT new com.docde.domain.medicalRecord.dto.response.PatientMedicalRecordResponseDto" +
-            "(m.patientRecordId, m.description, m.consultation, d.name) " +
-            "FROM MedicalRecord m JOIN m.doctor d WHERE m.patient.id = :patientId")
-    List<PatientMedicalRecordResponseDto> findByPatientId(Long patientId);*/
-
-
+public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Long>, MedicalRecordRepositoryCustom  {
 
     List<MedicalRecord> findByDoctorId(Long doctorId);
 

--- a/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepositoryCustom.java
+++ b/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.docde.domain.medicalRecord.repository;
+
+import com.docde.domain.medicalRecord.entity.MedicalRecord;
+
+import java.util.Optional;
+
+public interface MedicalRecordRepositoryCustom {
+    Optional<MedicalRecord> findSpecificMedicalRecord(Long medicalRecordId,
+                                                      String description,
+                                                      String treatmentPlan,
+                                                      String doctorComment);
+}

--- a/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepositoryImpl.java
+++ b/src/main/java/com/docde/domain/medicalRecord/repository/MedicalRecordRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.docde.domain.medicalRecord.repository;
+
+import com.docde.domain.medicalRecord.entity.MedicalRecord;
+import com.docde.domain.medicalRecord.repository.MedicalRecordRepositoryCustom;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.docde.domain.medicalRecord.entity.QMedicalRecord.medicalRecord;
+
+
+@Repository
+public class MedicalRecordRepositoryImpl implements MedicalRecordRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MedicalRecordRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Optional<MedicalRecord> findSpecificMedicalRecord(
+            Long medicalRecordId, String description, String treatmentPlan, String doctorComment) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(medicalRecord.medicalRecordId.eq(medicalRecordId));
+
+        if (description != null && !description.isEmpty()) {
+            builder.and(medicalRecord.description.contains(description));
+        }
+        if (treatmentPlan != null && !treatmentPlan.isEmpty()) {
+            builder.and(medicalRecord.treatmentPlan.contains(treatmentPlan));
+        }
+        if (doctorComment != null && !doctorComment.isEmpty()) {
+            builder.and(medicalRecord.doctorComment.contains(doctorComment));
+        }
+
+        return Optional.ofNullable(
+                queryFactory.selectFrom(medicalRecord)
+                        .where(builder)
+                        .fetchOne()
+        );
+
+    }
+}


### PR DESCRIPTION
…록 수정함

## 📝 
1.진료기록 특정 사용자 조회 추가(QueryDsl사용) -> url에 파람값 추가해 부분일치해도 조회가능
2. 의사용/환자용 진료기록으로 나누어(2개의 메소드) 수정했던 부분을 진료기록 자체로 수정하도록 변경.
 *진료기록을 수정하면 의사에게 보여지는 부분과 환자가 보여지는 부분이 다르기때문에, 진료기록을 수정해도 환자에게 몇가지 부분이 환자에게 보여지지않음*

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
2번에 관한 내용
![image](https://github.com/user-attachments/assets/46441924-0be7-44a8-97b1-032b7d1f033b)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
